### PR TITLE
fix(auth): corrige export do AuthContext que causava tela em branco

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
 
-const AuthContext = createContext(null);
+export const AuthContext = createContext(null);
+
 
 export function AuthProvider({ children }) {
     const [usuario, setUsuario] = useState(null);


### PR DESCRIPTION
## O que foi feito
- Corrigido export do AuthContext
- Ajustado para compatibilidade com imports existentes

## Problema resolvido
Após o merge na main, a aplicação apresentava tela em branco devido a erro:
"doesn't provide an export named 'AuthContext'"

## Como testar
1. Rodar o projeto
2. A aplicação deve renderizar normalmente sem erros no console
